### PR TITLE
Possible Fix for Forestry Preview build failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,4 +79,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Changed pinned bundler version, as Forestry seems to install bundler 2.0.2, and then fails to build using version 2.0.1