### PR TITLE
Preparation for Schema Standardization

### DIFF
--- a/_includes/guide-bosses.html
+++ b/_includes/guide-bosses.html
@@ -6,8 +6,12 @@
     <div class="guide__accordion-trigger--01 active" id="guideBosses">
         <i class="material-icons">expand_more</i>
         <h2 class="guide__accordion-trigger-title">
-            {% if page.instanceType == "dungeon" %}Dungeon Bosses{% endif %}
-            {% if page.instanceType == "raid" %}Raid Bosses{% endif %}
+            {% if page.bosses.size > 1 %}
+                {% if page.instanceType == "dungeon" %}Dungeon Bosses{% endif %}
+                {% if page.instanceType == "raid" %}Raid Bosses{% endif %}
+            {% else %}
+                {{ page.bosses[0].title }}
+            {% endif %}
         </h2>
     </div>
 
@@ -16,20 +20,22 @@
 
         <!-- Opens the Boss Loop -->
         {% for boss in page.bosses %}
+            {% if page.bosses.size > 1 %}                
+                <div class="guide__accordion-trigger--02" id="{{ boss.id }}">
+                    <i class="material-icons">expand_more</i>
+                    <h3 class="guide__accordion-trigger-title">
+                        {{ boss.title }}
+                    </h3>
+                </div>
 
-            <div class="guide__accordion-trigger--02" id="{{ boss.id }}">
-                <i class="material-icons">expand_more</i>
-                <h3 class="guide__accordion-trigger-title">
-                    {{ boss.title }}
-                </h3>
-            </div>
+                <div class="guide__accordion-content--02">
+            {% endif %}
 
-            <div class="guide__accordion-content--02">
 
                 <!-- Opens the Sequence Loop -->
                 {% for phase in boss.sequence %}
 
-                    <div class="guide__accordion-copy-wrapper">
+                    <div class="guide__accordion-copy-wrapper" id="phase{{ phase.phase }}">
 
                         <!-- Event Title -->
                         <h4 class="guide__accordion-title">Phase {{ phase.phase }} Alerts</h4>
@@ -77,7 +83,7 @@
 
                 {% endfor %}
 
-            </div>
+            {% if page.bosses.size > 1 %}</div>{% endif %}
 
         {% endfor %}
 

--- a/_includes/guide-metadata.html
+++ b/_includes/guide-metadata.html
@@ -23,7 +23,7 @@
 
             {% endif %}
 
-            {% if page.bosses %}
+            {% if page.bosses.size > 1 %}
 
                 <li>
 
@@ -46,27 +46,35 @@
 
                 </li>
 
-            {% endif %}
+            {% else %}
+                {% if page.sequence %}
+                    {% assign phases = page.sequence %}
+                {% elsif page.bosses[0].sequence %}
+                    {% assign phases = page.bosses[0].sequence %}
+                {% endif %}
 
-            {% if page.sequence %}
+                {% if phases %}
+                    
+                    <li>
 
-                <li>
+                        <a href="#" data-id="guideSummary" title="Go to the Guide Summary" class="guide-metadata__menu-link">Fight Summary</a>
 
-                    <a href="#" data-id="guideSummary" title="Go to the Guide Summary" class="guide-metadata__menu-link">Fight Summary</a>
+                        <ul class="guide-metadata__submenu">
 
-                    <ul class="guide-metadata__submenu">
+                            {% for phase in phases %}
 
-                        {% for phase in page.sequence %}
+                                <li>
+                                    <a href="#" data-id="phase{{ phase.phase }}" title="Go to Phase {{ phase.phase }}" class="guide-metadata__menu-link">Phase: {{ phase.phase }}</a>
+                                </li>
 
-                            <li>
-                                <a href="#" data-id="phase{{ phase.phase }}" title="Go to {{ phase.phase }}" class="guide-metadata__menu-link">Phase: {{ phase.phase }}</a>
-                            </li>
+                            {% endfor %}
 
-                        {% endfor %}
+                        </ul>
 
-                    </ul>
+                    </li>
 
-                </li>
+                {% endif %}
+                
 
             {% endif %}
 


### PR DESCRIPTION
Based on testing the front-end with a mocked up revised schema to standardize across all instance types, I've added logic to accommodate the specific differences I found.

These changes should prepare for a new standardized schema, while maintaining backwards compatibility with all previous content.

Tested with the following:
- Dungeon: Hell's Lid (Normal)
- Trial: Emanation (Extreme)
- Raid (8-person): Omega Deltascape V1 (Savage)
- Raid (24-person): Rabanastre
- (Seemingly) Old Schema: Ridorana